### PR TITLE
Update analytics.html

### DIFF
--- a/pinaxcon/templates/analytics.html
+++ b/pinaxcon/templates/analytics.html
@@ -1,14 +1,10 @@
 <script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new
-Date();a=s.createElement(o),
-
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-80204707-1', 'auto');
+  ga('create', 'UA-96249461-1', 'auto');
   ga('send', 'pageview');
 
 </script>


### PR DESCRIPTION
Pretty straight-forward change.  Just replaced the code / tracking ID that was there (LCA's?) with our own (pyconau).  Note, this will track pycon-au.org, not just this year's conference.  So, future conferences can use it, too, if they wish.