### PR TITLE
Example of how we might initialise rego.

### DIFF
--- a/fixtures/registrasion.json
+++ b/fixtures/registrasion.json
@@ -1,0 +1,61 @@
+[
+    {
+        "model": "registrasion.category",
+        "pk": 1,
+        "fields": {
+            "name": "Ticket",
+            "description": "Each type of ticket has different included products.  For details of what products are included, see our [LINK]registration details page.[/LINK]",
+            "required": true,
+            "render_type": 2,
+            "limit_per_user": 10,
+            "order": 10
+        }
+    },
+    {
+        "model": "registrasion.category",
+        "pk": 2,
+        "fields": {
+            "name": "Penguin Dinner Ticket",
+            "description": "Each type of ticket has different included products. For details of what products are included, see our [LINK]registration details page.[/LINK]",
+            "required": true,
+            "render_type": 1,
+            "limit_per_user": 1,
+            "order": 1
+        }
+    },
+    {
+        "model": "registrasion.category",
+        "pk": 1,
+        "fields": {
+            "name": "Speakers' Dinner Ticket",
+            "description": "Tickets to our exclusive Speakers' Dinner on the evening of Tuesday 17 January. You may purchase up to 5 tickets in total, for significant others, and family members.",
+            "required": false,
+            "render_type": 2,
+            "limit_per_user": 5,
+            "order": 20
+        }
+    },
+    {
+        "model": "registrasion.category",
+        "pk": 1,
+        "fields": {
+            "name": "Opening Reception Breakfast Ticket",
+            "description": "Tickets to our Opening Reception Breakfast. This                         event will be held on the morning of Monday 16                         January, and is restricted to Professional Ticket                         holders, speakers, miniconf organisers, and invited                         guests.",
+            "required": false,
+            "render_type": 1,
+            "limit_per_user": 1,
+            "order": 30
+        }
+    },
+     {
+        "model": "registrasion.category",
+        "pk": 1,
+        "fields": {
+            "name": "T-Shirt",
+            "description": "Commemorative conference t-shirts, featuring secret                         linux.conf.au 2017 artwork.",
+            "required": false,
+            "render_type": 3,
+            "order": 40
+        }
+    }
+]


### PR DESCRIPTION
(see fixtures/registrasion.json)

If you run 
```
python manage.py loaddata registrasion
```
the loaddata command will find the file named registrasion.json and load the models as described therein.

This does exactly the same thing as the first half-dozen or so calls to self.find_or_make in registrasion/management/commands/populate_inventory.py.  I'd like to populate the models this ways, if we could.