### PR TITLE
Improve rendering of home, content and news pages

### DIFF
--- a/pinaxcon/templates/cms_pages/abstract_content_page.html
+++ b/pinaxcon/templates/cms_pages/abstract_content_page.html
@@ -14,17 +14,7 @@
 {% if page.background_image %}
   {% block header_background_image %}{% image page.background_image width-2000 as background_image %}{{ background_image.url }}{% endblock %}
 {% endif %}
-{% block header_title %}{{ page.title }}{% endblock %}
-{% block header_paragraph %}{{ page.intro }}{% endblock %}
 {% block header_inset_image %}{% endblock %}
 
-{% block content %}
-    <div id="announcements" class="jumbotron-white">
-        <h1>{{ page.title }}</h1>
-        <p>{{ page.intro }}</p>
-        <span>{{ page.body }}</span>
-    </div>
-    {% block content_base %}
-    {% endblock %}
+{% block page_content %}
 {% endblock %}
-

--- a/pinaxcon/templates/cms_pages/content_page.html
+++ b/pinaxcon/templates/cms_pages/content_page.html
@@ -1,9 +1,7 @@
 {% extends "cms_pages/abstract_content_page.html" %}
-{% load pyconau2017_tags %}
 
-{% load sitetree %}
-{% load i18n %}
-
-{% block body_class %}template-content-page{% endblock %}
-
-{% block header_inset_image %}{% illustration page.inset_illustration %}{% endblock %}
+{% block page_content %}
+  <h1>{{ page.title }}</h1>
+  <p>{{ page.intro }}</p>
+  <span>{{ page.body }}</span>
+{% endblock %}

--- a/pinaxcon/templates/cms_pages/home_page.html
+++ b/pinaxcon/templates/cms_pages/home_page.html
@@ -1,13 +1,6 @@
-{% extends "site_base_wagtail.html" %}
+{% extends "cms_pages/abstract_content_page.html" %}
 
-{% load i18n %}
-
-{% load wagtailcore_tags %}
-
-{% block head_title %}{{ page.title }}{% endblock %}
-
-{% block body %}
-
-{{ page.body }}
-
+{% block page_content %}
+  <h1>{{ page.title }}</h1>
+  <span>{{ page.body }}</span>
 {% endblock %}

--- a/pinaxcon/templates/cms_pages/news_index_page.html
+++ b/pinaxcon/templates/cms_pages/news_index_page.html
@@ -1,47 +1,17 @@
 {% extends "cms_pages/abstract_content_page.html" %}
 
-{% load staticfiles %}
-{% load wagtailcore_tags %}
-{% load wagtailimages_tags %}
-{% load pyconau2017_tags %}
-
-{% load sitetree %}
-{% load i18n %}
-
-{% block head_title %}{{ page.title }}{% endblock %}
 {% block body_class %}template-news-index{% endblock %}
 
-{% block inset_image_base %}{% endblock %}
-
-{% comment %}We use panels here, so don't need to wrap in a text block{% endcomment %}
-{% block content_base %}
+{% block page_content %}
   {% if page.child_pages %}
     {% for item in page.child_pages %}
-      <div class="panel panel__compact jumbotron-white">
-        <div class="panel--content">
-        {% comment %}
-          <div class="panel--1-3">
-            <div class="portrait">
-              {% image item.portrait_image width-640 as portrait_image %}
-              <div style="background-image: url('{{ portrait_image.url }}');" class="portrait--img"></div>
-            </div>
-          </div>
-          {% endcomment %}
-          <div class="panel--2-3">
-            <h2>{{ item.title }}</h2>
-            <p class="lede"><em>{{ item.date|date:"j F Y" }}</em> – {{ item.intro }}</p>
-            <a href="{{ item.url }}" class="btn">Read more</a>
-          </div>
-        </div>
-      </div>
+        <h2>{{ item.title }}</h2>
+        <p class="lede"><em>{{ item.date|date:"j F Y" }}</em> – {{ item.intro }}</p>
+        <a href="{{ item.url }}" class="btn">Read more</a>
     {% endfor %}
     <div class="panel panel__compact"></div>
   {% endif %}
 
-  <div class="panel panel__compact jumbotron">
-    <div class="panel--content">
-      <h3>Subscribe</h3>
-      <p><a class="btn" href="rss">View as RSS</a></p>
-    </div>
-  </div>
+  <h3>Subscribe</h3>
+  <p><a class="btn" href="rss">View as RSS</a></p>
 {% endblock %}

--- a/pinaxcon/templates/cms_pages/news_page.html
+++ b/pinaxcon/templates/cms_pages/news_page.html
@@ -1,23 +1,12 @@
 {% extends "cms_pages/abstract_content_page.html" %}
 
-{% load wagtailcore_tags %}
-{% load wagtailimages_tags %}
-
-{% load sitetree %}
-{% load i18n %}
-
 {% block body_class %}template-newspage{% endblock %}
-
-{% block head_title %}{{ page.title }}{% endblock %}
 
 {% if page.portrait_image %}
   {% block header_inset_image %}{% image page.portrait_image width-640 as portrait_image %}{{ portrait_image.url }}{% endblock %}
 {% endif %}
 
-{% block content %}
-    <div id="announcements" class="jumbotron-white">
-
+{% block page_content %}
   <p><em>{{ page.date|date:"j F Y" }}</em></p>
   {{ page.body }}
-  </div>
 {% endblock %}

--- a/pinaxcon/templates/pyconau2017/content_page.html
+++ b/pinaxcon/templates/pyconau2017/content_page.html
@@ -12,29 +12,9 @@
 
 {% block head_title %}{% endblock %}
 
-{% comment %}
-{% block body_base %}
-{% block body %}
-
-  {% block heading_panel %}
-
-    {% block topbar_base %}
-    {% endblock %}
-  {% endblock %}
-
-  {% block content_base %}
-
-{% endcomment %}
-
-{% block content_base %}
 {% block content %}
+  <div class="page-content">
+   {% block page_content %}
+   {% endblock %}
+  </div>
 {% endblock %}
-{% endblock %}
-
-{% comment %}
-the name "extra_script" doesn't actually match the inherited name...
-{% block extra_script %}
-  <!-- script src="{% static 'js/site-92ae8d0d6c.js' %}" type="text/javascript"></script -->
-{% endblock %}
-{% endcomment %}
-

--- a/pinaxcon/templates/symposion/schedule/base.html
+++ b/pinaxcon/templates/symposion/schedule/base.html
@@ -9,8 +9,10 @@
     <main role="main">
     {% include "_messages.html" %}
     {% block body %}
+      <div class="page-content">
       {% block content %}
       {% endblock %}
+      </div>
     {% endblock %}
 {% endblock %}
 {% block scripts %}

--- a/pinaxcon/templates/symposion/schedule/presentation_detail.html
+++ b/pinaxcon/templates/symposion/schedule/presentation_detail.html
@@ -33,7 +33,7 @@
   {% endif %}
 {% endblock %}
 
-{% block content %}
+{% block page_content %}
 
   {% if presentation.unpublish %}
     <p><strong>Presentation not published.</strong></p>

--- a/pinaxcon/templates/symposion/schedule/schedule_conference.html
+++ b/pinaxcon/templates/symposion/schedule/schedule_conference.html
@@ -15,14 +15,12 @@
 {% block right %}
 {% endblock %}
 
-{% block content_base %}
+{% block page_content %}
 
   <div class="page-head">
     {% block breadcrumbs %}{% endblock %}
   </div>
 
-  <div class="panel panel__compact">
-    <div class="panel--content">
 
       <div class="panel--tab-controls">
         <div class="panel--tabs">
@@ -50,8 +48,6 @@
          {% endcache %}
       {% endfor %}
 
-    </div>
-  </div>
 {% endblock %}
 
 {% block scripts_extra %}

--- a/pinaxcon/templates/symposion/schedule/schedule_detail.html
+++ b/pinaxcon/templates/symposion/schedule/schedule_detail.html
@@ -13,7 +13,7 @@
 
 {% block body_class %}full{% endblock %}
 
-{% block content %}
+{% block page_content %}
   <div class="page-head">
     {% block breadcrumbs %}{% sitetree_breadcrumbs from "main" %}{% endblock %}
   </div>

--- a/pinaxcon/templates/symposion/schedule/schedule_edit.html
+++ b/pinaxcon/templates/symposion/schedule/schedule_edit.html
@@ -14,10 +14,6 @@
 {% endblock %}
 
 {% block content %}
-<div class="l-content-page">
-<div class="l-content-page--richtext">
-<div class="rich-text">
-
     <h1>Schedule Edit</h1>
 
     {% for timetable in days %}
@@ -30,7 +26,7 @@
         <input type="submit" id="delete" name="delete" value="Delete Schedule" />
     </form>
     <div class="modal fade in" style="background-color:#fff;" id="slotEditModal"></div>
-</div></div></div>
+
 {% endblock %}
 
 {% block extra_script %}

--- a/pinaxcon/templates/utility_page.html
+++ b/pinaxcon/templates/utility_page.html
@@ -8,7 +8,7 @@
 {% block header_title %}{% block page_title %}{% endblock %}{% endblock %}
 {% block header_inset_image_base %}{% endblock %}
 
-{% block content_base %}
+{% block page_content %}
   {% block utility_body_outer %}
         {% block content %}
           <div class="jumbotron-white">

--- a/static/src/pyconau2017/css/pyconau.css
+++ b/static/src/pyconau2017/css/pyconau.css
@@ -20,6 +20,17 @@ body {
   align-items: center;
 }
 
+.page-content {
+    background-color: rgba(255,255,255,1.0);
+    color: black;
+    margin-top: 60px;
+    margin-bottom: 60px;
+    border-radius: 6px;
+    padding: 2em;
+    border: solid #15B 2px;
+}
+
+
 .jumbotron {
     background-color: rgba(255,255,255,0.9);
     color: #2b2b2b;


### PR DESCRIPTION
Bring the various pages into a common structure of:

- pyconau2017/content_page.html which extends site_base_wagtail which extends site_base and defines a single content block called "page_content" which is enclosed in a single div class "page-content". This div's styling (pyconau.css) is the same as the jumbotron, but I don't like use continuing to enclose everything in jumbotron, it feels wrong :-)
- the various cms pages (content_page, news_page, etc.) all extend abstract_content_page which extends the above pyconau2017/content_page. The abstract page just adds a bunch of wagtail stuff, and leaves the page_content block alone for the underlying content_page, news_page etc. to fill in. You'll see that those pages are quite simple now.

Note that the home_page type is *raw HTML* and I guess we'll just deal with that.

There was a *lot* of duplication in the wagtail cms_pages templates (like multiple levels of setting page.title into the head_title block). I've removed those too.