### PR TITLE
Added title to news carousel.

### DIFF
--- a/pinaxcon/templates/pyconau2017/_news_carousel.html
+++ b/pinaxcon/templates/pyconau2017/_news_carousel.html
@@ -19,7 +19,7 @@
     {% else %}
     <div class="item">
     {% endif %}
-      <b>{{ item.date }}</b>
+      <b>{{ item.date }} - {{ item.title}}</i></b>
       <ul>
         {{ item.intro }}
         <p/>


### PR DESCRIPTION
Simple fix to add (inadvertently omitted) title to news item in carousel.