### PR TITLE
Remove superfluous backtic obscured by curly brace on line above.

### DIFF
--- a/pinaxcon/templates/symposion/sponsorship/_vertical_by_level.html
+++ b/pinaxcon/templates/symposion/sponsorship/_vertical_by_level.html
@@ -4,7 +4,7 @@
 
 <div class="sponsor-list">
 {% for level in levels %}
-`   {% if level.order < 100 %}
+    {% if level.order < 100 %}
         <h3>{{ level.name }}</h3>
         {% for sponsor in level.sponsors %}
             <div class="sponsor-list">


### PR DESCRIPTION
This resulted in a bunch of whitespace surrounding backtic in html output.

Removed