### PR TITLE
Feature/poke free specialist day ticket holders

### DIFF
--- a/pinaxcon/registrasion/management/commands/poke_specialist_ticketholders.py
+++ b/pinaxcon/registrasion/management/commands/poke_specialist_ticketholders.py
@@ -1,0 +1,59 @@
+
+import datetime
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from registrasion.models.commerce import Invoice, LineItem
+from registrasion.models.people import Attendee, AttendeeProfileBase
+from django.db.models import F, Q
+
+from registrasion.contrib.mail import send_email
+
+
+class Command(BaseCommand):
+    help = """Send email to ticket holders who get a free specialist day ticket but haven't yet signed up to use it."""
+
+    def add_arguments(self, parser):
+        parser.add_argument('--list-only', required=False, action="store_true", default=False,
+                            help='Just list the attendees -- no email sent')
+        parser.add_argument('--debug', required=False, action="store_true",  default=False,
+                            help='removes insects from your windscreen')
+        parser.add_argument('--count', required=False, action='store_true', default=False,
+                            help="Just say how many haven't yet signed up  (No email sent.)")
+        parser.add_argument('--kind', type=str, default="poke_unused_spec_day",
+                            help="name of registrasion/emails subdir holding the templates.")
+
+    def handle(self, *args, **options):
+
+        # Get all of the invoices for Professional / Sponsor / Contributor
+        # conference ticket holders.
+        eligible = list(set([li.invoice for li in LineItem.objects.
+                            filter(description__contains='Conference Ticket').
+                            filter(Q(description__contains='Professional')|
+                                   Q(description__contains='Contributor')|
+                                   Q(description__contains='Sponsor'))]))
+
+        # Look through these and find the ones that have no Specialist Day line item.
+        pokees = list()
+        for inv in eligible:
+            if not inv.lineitem_set.filter(description__contains='Specialist Day Inclusion').exists():
+                ap = AttendeeProfileBase.objects.get(attendee__user_id=inv.user.id)
+                pokees.append((ap.attendee_name(), inv.user.email))
+
+        # Just getting a list?
+        if options['list_only']:
+            for p in pokees:
+                print "%s\t%s" % p
+            return 0
+
+        # Just getting a count?
+        if options['count']:
+            print len(pokees)
+            return 0
+
+        # We want the whole magilla ...
+        send_email([("%s <%s>" % p) for p in pokees ], options['kind'], context={})
+
+        return 0
+
+
+

--- a/pinaxcon/registrasion/management/commands/poke_specialist_ticketholders.py
+++ b/pinaxcon/registrasion/management/commands/poke_specialist_ticketholders.py
@@ -33,15 +33,15 @@ class Command(BaseCommand):
                                    Q(description__contains='Sponsor'))]))
 
         # Look through these and find the ones that have no Specialist Day line item.
-        pokees = list()
+        pokees = dict()
         for inv in eligible:
             if not inv.lineitem_set.filter(description__contains='Specialist Day Inclusion').exists():
                 ap = AttendeeProfileBase.objects.get(attendee__user_id=inv.user.id)
-                pokees.append((ap.attendee_name(), inv.user.email))
+                pokees[inv.user.email] = ap.attendee_name()
 
         # Just getting a list?
         if options['list_only']:
-            for p in pokees:
+            for p in pokees.items():
                 print "%s\t%s" % p
             return 0
 
@@ -50,8 +50,10 @@ class Command(BaseCommand):
             print len(pokees)
             return 0
 
+        # Set up context ...
+
         # We want the whole magilla ...
-        send_email([("%s <%s>" % p) for p in pokees ], options['kind'], context={})
+        send_email([("%s <%s>" % (n,e)) for e,n in pokees.items() ], options['kind'], context={})
 
         return 0
 

--- a/pinaxcon/templates/registrasion/emails/poke_unused_spec_day/message.html
+++ b/pinaxcon/templates/registrasion/emails/poke_unused_spec_day/message.html
@@ -1,0 +1,9 @@
+Greetings!
+
+We noticed that you hadn't yet used your specialist day option, which is included
+with your conference ticket.
+
+There are only a few days left to sign up, so please do so soon as space is limited.
+
+Cheers,
+The PyCon AU 2017 Team

--- a/pinaxcon/templates/registrasion/emails/poke_unused_spec_day/subject.txt
+++ b/pinaxcon/templates/registrasion/emails/poke_unused_spec_day/subject.txt
@@ -1,0 +1,1 @@
+Included Specialist Day Ticket not yet used

--- a/pinaxcon/templates/registrasion/emails/poke_unused_spec_day_2/message.html
+++ b/pinaxcon/templates/registrasion/emails/poke_unused_spec_day_2/message.html
@@ -1,0 +1,2 @@
+
+This is an alternate kind!!

--- a/pinaxcon/templates/registrasion/emails/poke_unused_spec_day_2/subject.txt
+++ b/pinaxcon/templates/registrasion/emails/poke_unused_spec_day_2/subject.txt
@@ -1,0 +1,1 @@
+This is a test


### PR DESCRIPTION
This mgt command will find all of the attendees who have an included specilist day
but haven't actually redeemed the option.  

By default it will email those users.

There are a couple of cmd line switches:

--list-only:  just print out a list of these attendees -- no email sent
--count: just print out a count of the number of such attendees -- no email sent

--kind:  alternate template (directory) for subj and msg files.